### PR TITLE
Revert D46194126: Prepare bolts.Task to be safe to be usde from Kotlin

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/internal/bolts/Task.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/internal/bolts/Task.java
@@ -7,8 +7,6 @@
 
 package com.facebook.react.bridgeless.internal.bolts;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -61,14 +59,14 @@ public class Task<TResult> {
      * @param t the task
      * @param e the exception
      */
-    void unobservedException(@NonNull Task<?> t, @NonNull UnobservedTaskException e);
+    void unobservedException(Task<?> t, UnobservedTaskException e);
   }
 
   // null unless explicitly set
   private static volatile UnobservedExceptionHandler unobservedExceptionHandler;
 
   /** Returns the handler invoked when a task has an unobserved exception or {@code null}. */
-  public static @Nullable UnobservedExceptionHandler getUnobservedExceptionHandler() {
+  public static UnobservedExceptionHandler getUnobservedExceptionHandler() {
     return unobservedExceptionHandler;
   }
 
@@ -85,15 +83,15 @@ public class Task<TResult> {
   private final Object lock = new Object();
   private boolean complete;
   private boolean cancelled;
-  @Nullable private TResult result;
-  @Nullable private Exception error;
+  private TResult result;
+  private Exception error;
   private boolean errorHasBeenObserved;
-  @Nullable private UnobservedErrorNotifier unobservedErrorNotifier;
-  @Nullable private List<Continuation<TResult, Void>> continuations = new ArrayList<>();
+  private UnobservedErrorNotifier unobservedErrorNotifier;
+  private List<Continuation<TResult, Void>> continuations = new ArrayList<>();
 
   /* package */ Task() {}
 
-  private Task(@Nullable TResult result) {
+  private Task(TResult result) {
     trySetResult(result);
   }
 
@@ -105,7 +103,7 @@ public class Task<TResult> {
     }
   }
 
-  public static @NonNull <TResult> TaskCompletionSource create() {
+  public static <TResult> TaskCompletionSource create() {
     Task<TResult> task = new Task<>();
     return new TaskCompletionSource();
   }
@@ -135,14 +133,14 @@ public class Task<TResult> {
   }
 
   /** @return The result of the task, if set. {@code null} otherwise. */
-  public @Nullable TResult getResult() {
+  public TResult getResult() {
     synchronized (lock) {
       return result;
     }
   }
 
   /** @return The error for the task, if set. {@code null} otherwise. */
-  public @Nullable Exception getError() {
+  public Exception getError() {
     synchronized (lock) {
       if (error != null) {
         errorHasBeenObserved = true;
@@ -170,8 +168,7 @@ public class Task<TResult> {
    * @return {@code true} if the task completed (has a result, an error, or was cancelled). {@code
    *     false} otherwise.
    */
-  public boolean waitForCompletion(long duration, @NonNull TimeUnit timeUnit)
-      throws InterruptedException {
+  public boolean waitForCompletion(long duration, TimeUnit timeUnit) throws InterruptedException {
     synchronized (lock) {
       if (!isCompleted()) {
         lock.wait(timeUnit.toMillis(duration));
@@ -182,7 +179,7 @@ public class Task<TResult> {
 
   /** Creates a completed task with the given value. */
   @SuppressWarnings("unchecked")
-  public static @NonNull <TResult> Task<TResult> forResult(@Nullable TResult value) {
+  public static <TResult> Task<TResult> forResult(TResult value) {
     if (value == null) {
       return (Task<TResult>) TASK_NULL;
     }
@@ -195,7 +192,7 @@ public class Task<TResult> {
   }
 
   /** Creates a faulted task with the given error. */
-  public static @NonNull <TResult> Task<TResult> forError(@Nullable Exception error) {
+  public static <TResult> Task<TResult> forError(Exception error) {
     TaskCompletionSource<TResult> tcs = new TaskCompletionSource<>();
     tcs.setError(error);
     return tcs.getTask();
@@ -203,7 +200,7 @@ public class Task<TResult> {
 
   /** Creates a cancelled task. */
   @SuppressWarnings("unchecked")
-  public static @NonNull <TResult> Task<TResult> cancelled() {
+  public static <TResult> Task<TResult> cancelled() {
     return (Task<TResult>) TASK_CANCELLED;
   }
 
@@ -213,7 +210,7 @@ public class Task<TResult> {
    * @param delay The number of milliseconds to wait before completing the returned task. Zero and
    *     negative values are treated as requests for immediate execution.
    */
-  public static @NonNull Task<Void> delay(long delay) {
+  public static Task<Void> delay(long delay) {
     return delay(delay, BoltsExecutors.scheduled(), null);
   }
 
@@ -225,15 +222,12 @@ public class Task<TResult> {
    * @param cancellationToken The optional cancellation token that will be checked prior to
    *     completing the returned task.
    */
-  public static @NonNull Task<Void> delay(
-      long delay, @Nullable CancellationToken cancellationToken) {
+  public static Task<Void> delay(long delay, CancellationToken cancellationToken) {
     return delay(delay, BoltsExecutors.scheduled(), cancellationToken);
   }
 
-  /* package */ static @NonNull Task<Void> delay(
-      long delay,
-      @NonNull ScheduledExecutorService executor,
-      @Nullable final CancellationToken cancellationToken) {
+  /* package */ static Task<Void> delay(
+      long delay, ScheduledExecutorService executor, final CancellationToken cancellationToken) {
     if (cancellationToken != null && cancellationToken.isCancellationRequested()) {
       return Task.cancelled();
     }
@@ -272,14 +266,14 @@ public class Task<TResult> {
    * Makes a fluent cast of a Task's result possible, avoiding an extra continuation just to cast
    * the type of the result.
    */
-  public @NonNull <TOut> Task<TOut> cast() {
+  public <TOut> Task<TOut> cast() {
     @SuppressWarnings("unchecked")
     Task<TOut> task = (Task<TOut>) this;
     return task;
   }
 
   /** Turns a Task<T> into a Task<Void>, dropping any result. */
-  public @NonNull Task<Void> makeVoid() {
+  public Task<Void> makeVoid() {
     return this.continueWithTask(
         new Continuation<TResult, Task<Void>>() {
           @Override
@@ -301,14 +295,13 @@ public class Task<TResult> {
    * <p>If you want to cancel the resulting Task throw a {@link
    * java.util.concurrent.CancellationException} from the callable.
    */
-  public static @NonNull <TResult> Task<TResult> callInBackground(
-      @NonNull Callable<TResult> callable) {
+  public static <TResult> Task<TResult> callInBackground(Callable<TResult> callable) {
     return call(callable, BACKGROUND_EXECUTOR, null);
   }
 
   /** Invokes the callable on a background thread, returning a Task to represent the operation. */
-  public static @NonNull <TResult> Task<TResult> callInBackground(
-      @NonNull Callable<TResult> callable, @Nullable CancellationToken ct) {
+  public static <TResult> Task<TResult> callInBackground(
+      Callable<TResult> callable, CancellationToken ct) {
     return call(callable, BACKGROUND_EXECUTOR, ct);
   }
 
@@ -318,16 +311,13 @@ public class Task<TResult> {
    * <p>If you want to cancel the resulting Task throw a {@link
    * java.util.concurrent.CancellationException} from the callable.
    */
-  public static @NonNull <TResult> Task<TResult> call(
-      @NonNull final Callable<TResult> callable, @NonNull Executor executor) {
+  public static <TResult> Task<TResult> call(final Callable<TResult> callable, Executor executor) {
     return call(callable, executor, null);
   }
 
   /** Invokes the callable using the given executor, returning a Task to represent the operation. */
-  public static @NonNull <TResult> Task<TResult> call(
-      @NonNull final Callable<TResult> callable,
-      @NonNull Executor executor,
-      @Nullable final CancellationToken ct) {
+  public static <TResult> Task<TResult> call(
+      final Callable<TResult> callable, Executor executor, final CancellationToken ct) {
     final TaskCompletionSource<TResult> tcs = new TaskCompletionSource<>();
     try {
       executor.execute(
@@ -361,13 +351,13 @@ public class Task<TResult> {
    * <p>If you want to cancel the resulting Task throw a {@link
    * java.util.concurrent.CancellationException} from the callable.
    */
-  public static @NonNull <TResult> Task<TResult> call(@NonNull final Callable<TResult> callable) {
+  public static <TResult> Task<TResult> call(final Callable<TResult> callable) {
     return call(callable, IMMEDIATE_EXECUTOR, null);
   }
 
   /** Invokes the callable on the current thread, producing a Task. */
-  public static @NonNull <TResult> Task<TResult> call(
-      @NonNull final Callable<TResult> callable, @Nullable CancellationToken ct) {
+  public static <TResult> Task<TResult> call(
+      final Callable<TResult> callable, CancellationToken ct) {
     return call(callable, IMMEDIATE_EXECUTOR, ct);
   }
 
@@ -382,8 +372,8 @@ public class Task<TResult> {
    * @return A task that represents the completion of one of the supplied tasks. The return task's
    *     result is the task that completed.
    */
-  public static @NonNull <TResult> Task<Task<TResult>> whenAnyResult(
-      @NonNull Collection<? extends Task<TResult>> tasks) {
+  public static <TResult> Task<Task<TResult>> whenAnyResult(
+      Collection<? extends Task<TResult>> tasks) {
     if (tasks.size() == 0) {
       return Task.forResult(null);
     }
@@ -420,7 +410,7 @@ public class Task<TResult> {
    *     Result is the task that completed.
    */
   @SuppressWarnings("unchecked")
-  public static @NonNull Task<Task<?>> whenAny(@NonNull Collection<? extends Task<?>> tasks) {
+  public static Task<Task<?>> whenAny(Collection<? extends Task<?>> tasks) {
     if (tasks.size() == 0) {
       return Task.forResult(null);
     }
@@ -472,8 +462,8 @@ public class Task<TResult> {
    * @return A Task that will resolve to {@code List&lt;TResult&gt;} when all the tasks are
    *     resolved.
    */
-  public static @NonNull <TResult> Task<List<TResult>> whenAllResult(
-      @NonNull final Collection<? extends Task<TResult>> tasks) {
+  public static <TResult> Task<List<TResult>> whenAllResult(
+      final Collection<? extends Task<TResult>> tasks) {
     return whenAll(tasks)
         .onSuccess(
             new Continuation<Void, List<TResult>>() {
@@ -512,7 +502,7 @@ public class Task<TResult> {
    * @param tasks The tasks that the return value will wait for before completing.
    * @return A Task that will resolve to {@code Void} when all the tasks are resolved.
    */
-  public static @NonNull Task<Void> whenAll(@NonNull Collection<? extends Task<?>> tasks) {
+  public static Task<Void> whenAll(Collection<? extends Task<?>> tasks) {
     if (tasks.size() == 0) {
       return Task.forResult(null);
     }
@@ -568,8 +558,8 @@ public class Task<TResult> {
    * Continues a task with the equivalent of a Task-based while loop, where the body of the loop is
    * a task continuation.
    */
-  public @NonNull Task<Void> continueWhile(
-      @NonNull Callable<Boolean> predicate, @NonNull Continuation<Void, Task<Void>> continuation) {
+  public Task<Void> continueWhile(
+      Callable<Boolean> predicate, Continuation<Void, Task<Void>> continuation) {
     return continueWhile(predicate, continuation, IMMEDIATE_EXECUTOR, null);
   }
 
@@ -577,10 +567,10 @@ public class Task<TResult> {
    * Continues a task with the equivalent of a Task-based while loop, where the body of the loop is
    * a task continuation.
    */
-  public @NonNull Task<Void> continueWhile(
-      @NonNull Callable<Boolean> predicate,
-      @NonNull Continuation<Void, Task<Void>> continuation,
-      @Nullable CancellationToken ct) {
+  public Task<Void> continueWhile(
+      Callable<Boolean> predicate,
+      Continuation<Void, Task<Void>> continuation,
+      CancellationToken ct) {
     return continueWhile(predicate, continuation, IMMEDIATE_EXECUTOR, ct);
   }
 
@@ -588,10 +578,10 @@ public class Task<TResult> {
    * Continues a task with the equivalent of a Task-based while loop, where the body of the loop is
    * a task continuation.
    */
-  public @NonNull Task<Void> continueWhile(
-      @NonNull final Callable<Boolean> predicate,
-      @NonNull final Continuation<Void, Task<Void>> continuation,
-      @NonNull final Executor executor) {
+  public Task<Void> continueWhile(
+      final Callable<Boolean> predicate,
+      final Continuation<Void, Task<Void>> continuation,
+      final Executor executor) {
     return continueWhile(predicate, continuation, executor, null);
   }
 
@@ -599,11 +589,11 @@ public class Task<TResult> {
    * Continues a task with the equivalent of a Task-based while loop, where the body of the loop is
    * a task continuation.
    */
-  public @NonNull Task<Void> continueWhile(
-      @NonNull final Callable<Boolean> predicate,
-      @NonNull final Continuation<Void, Task<Void>> continuation,
-      @NonNull final Executor executor,
-      @Nullable final CancellationToken ct) {
+  public Task<Void> continueWhile(
+      final Callable<Boolean> predicate,
+      final Continuation<Void, Task<Void>> continuation,
+      final Executor executor,
+      final CancellationToken ct) {
     final Capture<Continuation<Void, Task<Void>>> predicateContinuation = new Capture<>();
     predicateContinuation.set(
         new Continuation<Void, Task<Void>>() {
@@ -629,9 +619,8 @@ public class Task<TResult> {
    * completes after the continuation has finished running. This allows the continuation to be
    * scheduled on different thread.
    */
-  public @NonNull <TContinuationResult> Task<TContinuationResult> continueWith(
-      @NonNull final Continuation<TResult, TContinuationResult> continuation,
-      @NonNull final Executor executor) {
+  public <TContinuationResult> Task<TContinuationResult> continueWith(
+      final Continuation<TResult, TContinuationResult> continuation, final Executor executor) {
     return continueWith(continuation, executor, null);
   }
 
@@ -640,10 +629,10 @@ public class Task<TResult> {
    * completes after the continuation has finished running. This allows the continuation to be
    * scheduled on different thread.
    */
-  public @NonNull <TContinuationResult> Task<TContinuationResult> continueWith(
-      @NonNull final Continuation<TResult, TContinuationResult> continuation,
-      @NonNull final Executor executor,
-      @Nullable final CancellationToken ct) {
+  public <TContinuationResult> Task<TContinuationResult> continueWith(
+      final Continuation<TResult, TContinuationResult> continuation,
+      final Executor executor,
+      final CancellationToken ct) {
     boolean completed;
     final TaskCompletionSource<TContinuationResult> tcs = new TaskCompletionSource<>();
     synchronized (lock) {
@@ -669,8 +658,8 @@ public class Task<TResult> {
    * Adds a synchronous continuation to this task, returning a new task that completes after the
    * continuation has finished running.
    */
-  public @NonNull <TContinuationResult> Task<TContinuationResult> continueWith(
-      @NonNull Continuation<TResult, TContinuationResult> continuation) {
+  public <TContinuationResult> Task<TContinuationResult> continueWith(
+      Continuation<TResult, TContinuationResult> continuation) {
     return continueWith(continuation, IMMEDIATE_EXECUTOR, null);
   }
 
@@ -678,9 +667,8 @@ public class Task<TResult> {
    * Adds a synchronous continuation to this task, returning a new task that completes after the
    * continuation has finished running.
    */
-  public @NonNull <TContinuationResult> Task<TContinuationResult> continueWith(
-      @NonNull Continuation<TResult, TContinuationResult> continuation,
-      @Nullable CancellationToken ct) {
+  public <TContinuationResult> Task<TContinuationResult> continueWith(
+      Continuation<TResult, TContinuationResult> continuation, CancellationToken ct) {
     return continueWith(continuation, IMMEDIATE_EXECUTOR, ct);
   }
 
@@ -688,9 +676,9 @@ public class Task<TResult> {
    * Adds an Task-based continuation to this task that will be scheduled using the executor,
    * returning a new task that completes after the task returned by the continuation has completed.
    */
-  public @NonNull <TContinuationResult> Task<TContinuationResult> continueWithTask(
-      @NonNull final Continuation<TResult, Task<TContinuationResult>> continuation,
-      @NonNull final Executor executor) {
+  public <TContinuationResult> Task<TContinuationResult> continueWithTask(
+      final Continuation<TResult, Task<TContinuationResult>> continuation,
+      final Executor executor) {
     return continueWithTask(continuation, executor, null);
   }
 
@@ -698,10 +686,10 @@ public class Task<TResult> {
    * Adds an Task-based continuation to this task that will be scheduled using the executor,
    * returning a new task that completes after the task returned by the continuation has completed.
    */
-  public @NonNull <TContinuationResult> Task<TContinuationResult> continueWithTask(
-      @NonNull final Continuation<TResult, Task<TContinuationResult>> continuation,
-      @NonNull final Executor executor,
-      @Nullable final CancellationToken ct) {
+  public <TContinuationResult> Task<TContinuationResult> continueWithTask(
+      final Continuation<TResult, Task<TContinuationResult>> continuation,
+      final Executor executor,
+      final CancellationToken ct) {
     boolean completed;
     final TaskCompletionSource<TContinuationResult> tcs = new TaskCompletionSource<>();
     synchronized (lock) {
@@ -727,8 +715,8 @@ public class Task<TResult> {
    * Adds an asynchronous continuation to this task, returning a new task that completes after the
    * task returned by the continuation has completed.
    */
-  public @NonNull <TContinuationResult> Task<TContinuationResult> continueWithTask(
-      @NonNull Continuation<TResult, Task<TContinuationResult>> continuation) {
+  public <TContinuationResult> Task<TContinuationResult> continueWithTask(
+      Continuation<TResult, Task<TContinuationResult>> continuation) {
     return continueWithTask(continuation, IMMEDIATE_EXECUTOR, null);
   }
 
@@ -736,9 +724,8 @@ public class Task<TResult> {
    * Adds an asynchronous continuation to this task, returning a new task that completes after the
    * task returned by the continuation has completed.
    */
-  public @NonNull <TContinuationResult> Task<TContinuationResult> continueWithTask(
-      @NonNull Continuation<TResult, Task<TContinuationResult>> continuation,
-      @Nullable CancellationToken ct) {
+  public <TContinuationResult> Task<TContinuationResult> continueWithTask(
+      Continuation<TResult, Task<TContinuationResult>> continuation, CancellationToken ct) {
     return continueWithTask(continuation, IMMEDIATE_EXECUTOR, ct);
   }
 
@@ -746,9 +733,8 @@ public class Task<TResult> {
    * Runs a continuation when a task completes successfully, forwarding along {@link
    * java.lang.Exception} or cancellation.
    */
-  public @NonNull <TContinuationResult> Task<TContinuationResult> onSuccess(
-      @NonNull final Continuation<TResult, TContinuationResult> continuation,
-      @NonNull Executor executor) {
+  public <TContinuationResult> Task<TContinuationResult> onSuccess(
+      final Continuation<TResult, TContinuationResult> continuation, Executor executor) {
     return onSuccess(continuation, executor, null);
   }
 
@@ -756,10 +742,10 @@ public class Task<TResult> {
    * Runs a continuation when a task completes successfully, forwarding along {@link
    * java.lang.Exception} or cancellation.
    */
-  public @NonNull <TContinuationResult> Task<TContinuationResult> onSuccess(
-      @NonNull final Continuation<TResult, TContinuationResult> continuation,
-      @NonNull Executor executor,
-      @Nullable final CancellationToken ct) {
+  public <TContinuationResult> Task<TContinuationResult> onSuccess(
+      final Continuation<TResult, TContinuationResult> continuation,
+      Executor executor,
+      final CancellationToken ct) {
     return continueWithTask(
         new Continuation<TResult, Task<TContinuationResult>>() {
           @Override
@@ -784,8 +770,8 @@ public class Task<TResult> {
    * Runs a continuation when a task completes successfully, forwarding along {@link
    * java.lang.Exception}s or cancellation.
    */
-  public @NonNull <TContinuationResult> Task<TContinuationResult> onSuccess(
-      @NonNull final Continuation<TResult, TContinuationResult> continuation) {
+  public <TContinuationResult> Task<TContinuationResult> onSuccess(
+      final Continuation<TResult, TContinuationResult> continuation) {
     return onSuccess(continuation, IMMEDIATE_EXECUTOR, null);
   }
 
@@ -793,9 +779,8 @@ public class Task<TResult> {
    * Runs a continuation when a task completes successfully, forwarding along {@link
    * java.lang.Exception}s or cancellation.
    */
-  public @NonNull <TContinuationResult> Task<TContinuationResult> onSuccess(
-      @NonNull final Continuation<TResult, TContinuationResult> continuation,
-      @Nullable CancellationToken ct) {
+  public <TContinuationResult> Task<TContinuationResult> onSuccess(
+      final Continuation<TResult, TContinuationResult> continuation, CancellationToken ct) {
     return onSuccess(continuation, IMMEDIATE_EXECUTOR, ct);
   }
 
@@ -803,9 +788,8 @@ public class Task<TResult> {
    * Runs a continuation when a task completes successfully, forwarding along {@link
    * java.lang.Exception}s or cancellation.
    */
-  public @NonNull <TContinuationResult> Task<TContinuationResult> onSuccessTask(
-      @NonNull final Continuation<TResult, Task<TContinuationResult>> continuation,
-      @NonNull Executor executor) {
+  public <TContinuationResult> Task<TContinuationResult> onSuccessTask(
+      final Continuation<TResult, Task<TContinuationResult>> continuation, Executor executor) {
     return onSuccessTask(continuation, executor, null);
   }
 
@@ -813,10 +797,10 @@ public class Task<TResult> {
    * Runs a continuation when a task completes successfully, forwarding along {@link
    * java.lang.Exception}s or cancellation.
    */
-  public @NonNull <TContinuationResult> Task<TContinuationResult> onSuccessTask(
-      @NonNull final Continuation<TResult, Task<TContinuationResult>> continuation,
-      @NonNull Executor executor,
-      @Nullable final CancellationToken ct) {
+  public <TContinuationResult> Task<TContinuationResult> onSuccessTask(
+      final Continuation<TResult, Task<TContinuationResult>> continuation,
+      Executor executor,
+      final CancellationToken ct) {
     return continueWithTask(
         new Continuation<TResult, Task<TContinuationResult>>() {
           @Override
@@ -841,8 +825,8 @@ public class Task<TResult> {
    * Runs a continuation when a task completes successfully, forwarding along {@link
    * java.lang.Exception}s or cancellation.
    */
-  public @NonNull <TContinuationResult> Task<TContinuationResult> onSuccessTask(
-      @NonNull final Continuation<TResult, Task<TContinuationResult>> continuation) {
+  public <TContinuationResult> Task<TContinuationResult> onSuccessTask(
+      final Continuation<TResult, Task<TContinuationResult>> continuation) {
     return onSuccessTask(continuation, IMMEDIATE_EXECUTOR);
   }
 
@@ -850,9 +834,8 @@ public class Task<TResult> {
    * Runs a continuation when a task completes successfully, forwarding along {@link
    * java.lang.Exception}s or cancellation.
    */
-  public @NonNull <TContinuationResult> Task<TContinuationResult> onSuccessTask(
-      @NonNull final Continuation<TResult, Task<TContinuationResult>> continuation,
-      @Nullable CancellationToken ct) {
+  public <TContinuationResult> Task<TContinuationResult> onSuccessTask(
+      final Continuation<TResult, Task<TContinuationResult>> continuation, CancellationToken ct) {
     return onSuccessTask(continuation, IMMEDIATE_EXECUTOR, ct);
   }
 
@@ -868,11 +851,11 @@ public class Task<TResult> {
    *     be scheduled on a different thread).
    */
   private static <TContinuationResult, TResult> void completeImmediately(
-      @NonNull final TaskCompletionSource<TContinuationResult> tcs,
-      @NonNull final Continuation<TResult, TContinuationResult> continuation,
-      @NonNull final Task<TResult> task,
-      @NonNull Executor executor,
-      @Nullable final CancellationToken ct) {
+      final TaskCompletionSource<TContinuationResult> tcs,
+      final Continuation<TResult, TContinuationResult> continuation,
+      final Task<TResult> task,
+      Executor executor,
+      final CancellationToken ct) {
     try {
       executor.execute(
           new Runnable() {
@@ -911,11 +894,11 @@ public class Task<TResult> {
    *     be scheduled on a different thread).
    */
   private static <TContinuationResult, TResult> void completeAfterTask(
-      @NonNull final TaskCompletionSource<TContinuationResult> tcs,
-      @NonNull final Continuation<TResult, Task<TContinuationResult>> continuation,
-      @NonNull final Task<TResult> task,
-      @NonNull final Executor executor,
-      @Nullable final CancellationToken ct) {
+      final TaskCompletionSource<TContinuationResult> tcs,
+      final Continuation<TResult, Task<TContinuationResult>> continuation,
+      final Task<TResult> task,
+      final Executor executor,
+      final CancellationToken ct) {
     try {
       executor.execute(
           new Runnable() {
@@ -934,7 +917,7 @@ public class Task<TResult> {
                   result.continueWith(
                       new Continuation<TContinuationResult, Void>() {
                         @Override
-                        public Void then(@NonNull Task<TContinuationResult> task) {
+                        public Void then(Task<TContinuationResult> task) {
                           if (ct != null && ct.isCancellationRequested()) {
                             tcs.setCancelled();
                             return null;
@@ -993,7 +976,7 @@ public class Task<TResult> {
   }
 
   /** Sets the result on the Task if the Task hasn't already been completed. */
-  /* package */ boolean trySetResult(@Nullable TResult result) {
+  /* package */ boolean trySetResult(TResult result) {
     synchronized (lock) {
       if (complete) {
         return false;
@@ -1007,7 +990,7 @@ public class Task<TResult> {
   }
 
   /** Sets the error on the Task if the Task hasn't already been completed. */
-  /* package */ boolean trySetError(@Nullable Exception error) {
+  /* package */ boolean trySetError(Exception error) {
     synchronized (lock) {
       if (complete) {
         return false;
@@ -1023,8 +1006,8 @@ public class Task<TResult> {
     }
   }
 
-  private static final Task<?> TASK_NULL = new Task<>(null);
-  private static final Task<Boolean> TASK_TRUE = new Task<>((Boolean) true);
-  private static final Task<Boolean> TASK_FALSE = new Task<>((Boolean) false);
-  private static final Task<?> TASK_CANCELLED = new Task(true);
+  private static Task<?> TASK_NULL = new Task<>(null);
+  private static Task<Boolean> TASK_TRUE = new Task<>((Boolean) true);
+  private static Task<Boolean> TASK_FALSE = new Task<>((Boolean) false);
+  private static Task<?> TASK_CANCELLED = new Task(true);
 }


### PR DESCRIPTION
Differential Revision:
D46194126

Original commit changeset: 765af7683fa6

Original Phabricator Diff: D46194126

fbshipit-source-id: e35e25dada9006c654cf02f269f3c1c6fc5c6b13

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
